### PR TITLE
FMFA-359: Add check to execute role active/deactive actions only on active host; not standby

### DIFF
--- a/tasks/register-dcd.yaml
+++ b/tasks/register-dcd.yaml
@@ -32,6 +32,22 @@
     X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: regchk
 
+- name: Get ha status
+  uri:
+    url: "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/failover-state"
+    timeout: "{{ register_cm_timeout }}"
+    validate_certs: "{{ register_cm_validate_certs }}"
+    headers:
+      X-F5-Auth-Token: "{{ f5_auth_token }}"
+  register: ha
+
+- name: Ensure HA state was recieved
+  fail:
+    msg: "There was problem with getting HA state. Please ensure that BIGIQ system started"
+  when: >
+    ha.json is undefined or
+    ha.json.systemMode is undefined
+
 - name: Get devices from CM
   set_fact:
    devices: "{{ regchk.json | json_query('items[*].address') }}"
@@ -40,6 +56,7 @@
   when:
    - register_dcd_server not in devices
    - hostvars[inventory_hostname]['haprimary']
+   - ha.json.nodeRole != 'SECONDARY'
 
 - name: Get DCD Device Reference
   uri:
@@ -58,4 +75,6 @@
 
 - name: activate all services on dcd
   include_tasks: activate-all-services.yaml
-  when: hostvars[inventory_hostname]['haprimary']
+  when: >
+    hostvars[inventory_hostname]['haprimary'] and
+    ha.json.nodeRole != 'SECONDARY'

--- a/tasks/register-dcd.yaml
+++ b/tasks/register-dcd.yaml
@@ -32,6 +32,22 @@
     X-F5-Auth-Token: "{{ f5_auth_token }}"
   register: regchk
 
+- name: Get ha status
+  uri:
+   url: "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/failover-state"
+   timeout: "{{ register_cm_timeout }}"
+   validate_certs: "{{ register_cm_validate_certs }}"
+   headers:
+    X-F5-Auth-Token: "{{ f5_auth_token }}"
+  register: ha
+
+- name: Ensure HA state was recieved
+  fail:
+   msg: "There was problem with getting HA state. Please ensure that BIGIQ system started"
+  when: >
+    ha.json is undefined or
+    ha.json.systemMode is undefined
+
 - name: Get devices from CM
   set_fact:
    devices: "{{ regchk.json | json_query('items[*].address') }}"
@@ -40,6 +56,7 @@
   when:
    - register_dcd_server not in devices
    - hostvars[inventory_hostname]['haprimary']
+   - ha.json.nodeRole != 'SECONDARY'
 
 - name: Get DCD Device Reference
   uri:
@@ -58,4 +75,6 @@
 
 - name: activate all services on dcd
   include_tasks: activate-all-services.yaml
-  when: hostvars[inventory_hostname]['haprimary']
+  when: >
+    hostvars[inventory_hostname]['haprimary'] and
+    ha.json.nodeRole != 'SECONDARY'


### PR DESCRIPTION
### Summary 

This change is intended to introduce a check which prevents role execution on stand-by host. 


### Changes 

 - updated register-dcd.yaml to get HA state and prevent active/deactivate actions on host which has nodeRole field is set to 'SECONDARY'


### Additional information