### PR TITLE
Fix Request failed: <urlopen error unknown url type: \"https>

### DIFF
--- a/tasks/register-dcd.yaml
+++ b/tasks/register-dcd.yaml
@@ -60,8 +60,7 @@
 - name: Get DCD Device Reference
   uri:
    url: |
-     "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/resolver/device-groups/cm-esmgmt-logging-group/
-     devices/?$select=selfLink,properties&$filter=address+eq+'{{ register_dcd_server }}'"
+     "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/resolver/device-groups/cm-esmgmt-logging-group/devices/?$select=selfLink,properties&$filter=address+eq+'{{ register_dcd_server }}'"
    timeout: "{{ register_cm_timeout }}"
    validate_certs: "{{ register_cm_validate_certs }}"
    headers:

--- a/tasks/register-dcd.yaml
+++ b/tasks/register-dcd.yaml
@@ -59,8 +59,7 @@
 
 - name: Get DCD Device Reference
   uri:
-   url: |
-     "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/resolver/device-groups/cm-esmgmt-logging-group/devices/?$select=selfLink,properties&$filter=address+eq+'{{ register_dcd_server }}'"
+   url: "https://{{ provider.server }}:{{ provider.server_port }}/mgmt/shared/resolver/device-groups/cm-esmgmt-logging-group/devices/?$select=selfLink,properties&$filter=address+eq+'{{ register_dcd_server }}'"
    timeout: "{{ register_cm_timeout }}"
    validate_certs: "{{ register_cm_validate_certs }}"
    headers:


### PR DESCRIPTION
Probably some changes in Ansible/Python latest

```
ansible-playbook 2.9.10
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.8/dist-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.8.2 (default, Apr 27 2020, 15:53:34) [GCC 9.3.0]
```

I am getting this error with URL defined in Get DCD Device Reference tasks.

```
           "status_code": [
                200
            ],
            "timeout": 120,
            "unix_socket": null,
            "unsafe_writes": null,
            "url": "\"https://1.2.3.4:443/mgmt/shared/resolver/device-groups/cm-esmgmt-logging-group/devices/?$select=selfLink,properties&$filter=address+eq+'1.2.3.44'\"\n",
            "url_password": null,
            "url_username": null,
            "use_proxy": true,
            "validate_certs": false
        }
    },
    "msg": "Status code was -1 and not [200]: Request failed: <urlopen error unknown url type: \"https>",
    "redirected": false,
    "status": -1,
    "url": "\"https://1.2.3.4:443/mgmt/shared/resolver/device-groups/cm-esmgmt-logging-group/devices/?$select=selfLink,properties&$filter=address+eq+'1.2.3.44'\"\n"
}
```
Changed the expression from multi lines to 1 line makes it work just fine.